### PR TITLE
Meecrowave Server Side Event and Web Socket Integration tests

### DIFF
--- a/integration-tests/sse/pom.xml
+++ b/integration-tests/sse/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>integration-tests</artifactId>
+        <groupId>org.apache.meecrowave</groupId>
+        <version>1.2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sse</artifactId>
+    <packaging>war</packaging>
+    <name>Meecrowave :: Integration Tests :: Server Side Events</name>
+
+    <properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.meecrowave</groupId>
+            <artifactId>meecrowave-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-sse</artifactId>
+            <version>${cxf.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- JSR 356 web sockets only, both client and server need tomcat dependency. 
+        Without client only tomcat-websocket-api in the maven provided scope is necessary-->
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-websocket</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency> 
+        <!-- JSR 356 web socket only for JSON-P decoding -->
+        <dependency>
+            <groupId>org.apache.johnzon</groupId>
+            <artifactId>johnzon-websocket</artifactId>
+            <version>${johnzon.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.meecrowave</groupId>
+            <artifactId>meecrowave-junit</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    <!--  for atmosphere logging -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.version}</version>
+            <scope>test</scope>
+        </dependency>
+    <!-- for JSR-356 client, couldnt' find CXF alternative. Need to check if license is compatible
+        <dependency>
+            <groupId>org.glassfish.tyrus</groupId>
+            <artifactId>tyrus-client</artifactId>
+            <version>1.13.1</version>
+            <scope>test</scope>
+        </dependency>-->
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.meecrowave</groupId>
+                <artifactId>meecrowave-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <scanningPackageIncludes>org.apache.meecrowave.tests.sse, org.apache.meecrowave.tests.ws</scanningPackageIncludes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.cxf</groupId>
+                        <artifactId>cxf-rt-rs-sse</artifactId>
+                        <version>${cxf.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.tomcat</groupId>
+                        <artifactId>tomcat-websocket</artifactId>
+                        <version>${tomcat.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.johnzon</groupId>
+                        <artifactId>johnzon-websocket</artifactId>
+                        <version>${johnzon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                        <version>${log4j2.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/sse/src/main/java/org/apache/meecrowave/tests/sse/NewsService.java
+++ b/integration-tests/sse/src/main/java/org/apache/meecrowave/tests/sse/NewsService.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.meecrowave.tests.sse;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.sse.Sse;
+import javax.ws.rs.sse.SseEventSink;
+
+@Path("/news")
+@ApplicationScoped
+public class NewsService {
+
+	AtomicInteger newsCounter = new AtomicInteger();
+
+	@GET
+	@Path("/")
+	public Response news() {
+		JsonObject news = Json.createObjectBuilder().add("news", "online").build();
+		return Response.status(Response.Status.OK).entity(news).build();
+	}
+	
+	
+	@GET
+	@Path("/update")
+	@Produces(MediaType.SERVER_SENT_EVENTS)
+	public void newsUpdate(@Context SseEventSink eventSink, @Context Sse sse) {
+		CompletableFuture.runAsync(() -> {
+			IntStream.range(1, 6).forEach(c -> {
+				JsonObject newsEvent = Json.createObjectBuilder().add("news", String.format("Updated Event %d", newsCounter.incrementAndGet())).build();
+				eventSink.send(sse.newEventBuilder().mediaType(MediaType.APPLICATION_JSON_TYPE).data(newsEvent).build());
+			});
+			//closing only on the client is generating a chunked connection exception that can be troubleshooted at a later date.
+			eventSink.close();
+		});
+	}
+
+}

--- a/integration-tests/sse/src/main/java/org/apache/meecrowave/tests/sse/RSApplication.java
+++ b/integration-tests/sse/src/main/java/org/apache/meecrowave/tests/sse/RSApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.meecrowave.tests.sse;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/rs")
+public class RSApplication extends Application {
+
+	
+}

--- a/integration-tests/sse/src/main/java/org/apache/meecrowave/tests/sse/SSECDIExtension.java
+++ b/integration-tests/sse/src/main/java/org/apache/meecrowave/tests/sse/SSECDIExtension.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.meecrowave.tests.sse;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+import org.apache.cxf.jaxrs.sse.cdi.SseTransportCustomizationExtension;
+
+//This will not be needed in the future https://github.com/apache/cxf/pull/369
+public class SSECDIExtension implements Extension {
+
+	void addBeansFromJava(@Observes final BeforeBeanDiscovery bbd, final BeanManager bm) {
+		bbd.addAnnotatedType(bm.createAnnotatedType(SseTransportCustomizationExtension.class));
+	}
+}

--- a/integration-tests/sse/src/main/java/org/apache/meecrowave/tests/ws/ChatWS.java
+++ b/integration-tests/sse/src/main/java/org/apache/meecrowave/tests/ws/ChatWS.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.meecrowave.tests.ws;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.websocket.CloseReason;
+import javax.websocket.CloseReason.CloseCodes;
+import javax.websocket.EncodeException;
+import javax.websocket.OnClose;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+
+import org.apache.johnzon.websocket.jsr.JsrObjectDecoder;
+import org.apache.johnzon.websocket.jsr.JsrObjectEncoder;
+
+@ServerEndpoint(value = "/ws-chat", encoders = { JsrObjectEncoder.class }, decoders = { JsrObjectDecoder.class })
+public class ChatWS {
+
+	AtomicInteger chatCounter = new AtomicInteger();
+
+	@OnOpen
+	public void onOpen(Session session) {
+
+	}
+
+	@OnClose
+	public void onClose() {
+
+	}
+
+	@OnMessage
+	public void message(Session session, JsonObject msg) {		
+		try {
+			if (!"ping".equals(msg.getString("chat"))) {
+				session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION, String.format("unexpected chat value %s", msg.getString("chat"))));
+			}
+			JsonObject pong = Json.createObjectBuilder().add("chat", "pong " + chatCounter.incrementAndGet()).build();
+			session.getBasicRemote().sendObject(pong);
+		} catch (IOException | EncodeException e) {
+			e.printStackTrace();
+		}
+
+	}
+
+}

--- a/integration-tests/sse/src/main/resources/META-INF/beans.xml
+++ b/integration-tests/sse/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,19 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<beans />

--- a/integration-tests/sse/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/integration-tests/sse/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.apache.meecrowave.tests.sse.SSECDIExtension

--- a/integration-tests/sse/src/main/resources/META-INF/services/javax.ws.rs.sse.SseEventSource.Builder
+++ b/integration-tests/sse/src/main/resources/META-INF/services/javax.ws.rs.sse.SseEventSource.Builder
@@ -1,0 +1,1 @@
+org.apache.cxf.jaxrs.sse.client.SseEventSourceBuilderImpl

--- a/integration-tests/sse/src/test/java/org/apache/meecrowave/tests/sse/SSETest.java
+++ b/integration-tests/sse/src/test/java/org/apache/meecrowave/tests/sse/SSETest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.meecrowave.tests.sse;
+
+import java.net.MalformedURLException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.json.JsonObject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.sse.SseEventSource;
+
+import org.apache.johnzon.jaxrs.JsrProvider;
+import org.apache.meecrowave.Meecrowave;
+import org.apache.meecrowave.junit.MeecrowaveRule;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SSETest {
+	@ClassRule
+	public static final MeecrowaveRule CONTAINER = new MeecrowaveRule(new Meecrowave.Builder()
+			.randomHttpPort()
+			.excludePackages("org.atmosphere")
+			.cxfServletParam("transportId", "http://cxf.apache.org/transports/http/sse")
+			//.cxfServletParam("jaxrs.scope", "singleton")
+			.cxfServletParam("org.atmosphere.container.JSR356AsyncSupport.mappingPath", "/*").
+			includePackages(NewsService.class.getPackage().getName()), "");
+
+	public static final Client client = ClientBuilder.newBuilder().register(JsrProvider.class).build();
+
+	@Test
+	public void normal() {
+		//Make sure normal JAX-RS requests function with SSE enabled
+		WebTarget base = client.target(String.format("http://localhost:%d", CONTAINER.getConfiguration().getHttpPort()));
+		Response response = base.path("/rs/news").request().get();
+		assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+		JsonObject responseJson = response.readEntity(JsonObject.class);
+		assertEquals("online", responseJson.getString("news"));
+	}
+
+	@Test
+	public void sse() throws MalformedURLException, InterruptedException {
+		WebTarget base = client.target(String.format("http://localhost:%d", CONTAINER.getConfiguration().getHttpPort()));
+		//the /META-INF/services/javax.ws.rs.sse.SseEventSource.Builder file is only needed until this is fixed:
+		//https://issues.apache.org/jira/browse/CXF-7633
+		//An exception is not thrown on a 404 response but that is not a Meecrowave issue.
+		try (final SseEventSource eventSource = SseEventSource.target(base.path("/rs/news/update")).build()) {
+			CountDownLatch cdl = new CountDownLatch(5);
+			eventSource.register(sse -> {
+				JsonObject data = sse.readData(JsonObject.class, MediaType.APPLICATION_JSON_TYPE);
+				assertNotNull(data);
+				cdl.countDown();
+			}, e -> {
+				e.printStackTrace();
+				fail(e.getMessage());
+
+			});
+			eventSource.open();
+			assertTrue(cdl.await(20, TimeUnit.SECONDS));
+			assertTrue(eventSource.close(5, TimeUnit.SECONDS));
+		}
+	}
+}

--- a/integration-tests/sse/src/test/java/org/apache/meecrowave/tests/ws/WSTest.java
+++ b/integration-tests/sse/src/test/java/org/apache/meecrowave/tests/ws/WSTest.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.meecrowave.tests.ws;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.websocket.ClientEndpoint;
+import javax.websocket.CloseReason;
+import javax.websocket.ContainerProvider;
+import javax.websocket.DeploymentException;
+import javax.websocket.EncodeException;
+import javax.websocket.OnClose;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+
+import org.apache.johnzon.websocket.jsr.JsrObjectDecoder;
+import org.apache.johnzon.websocket.jsr.JsrObjectEncoder;
+import org.apache.meecrowave.Meecrowave;
+import org.apache.meecrowave.junit.MeecrowaveRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class WSTest {
+	@ClassRule
+	public static final MeecrowaveRule CONTAINER = new MeecrowaveRule(new Meecrowave.Builder()
+			.randomHttpPort()
+			.includePackages(ChatWS.class.getPackage().getName()), "");
+
+	@Test
+	public void run() throws InterruptedException, DeploymentException, IOException, URISyntaxException {
+		CountDownLatch cdl = new CountDownLatch(5);
+		WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+		String wsEndpoint = String.format("ws://localhost:%d/ws-chat", CONTAINER.getConfiguration().getHttpPort());
+		Session session = container.connectToServer(new ChatClient(cdl), new URI(wsEndpoint));
+		assertTrue(cdl.await(20, TimeUnit.SECONDS));
+		session.close();
+
+	}
+
+	@ClientEndpoint(encoders = JsrObjectEncoder.class, decoders = JsrObjectDecoder.class)
+	public class ChatClient {
+
+		private CountDownLatch cdl;
+
+		public ChatClient(CountDownLatch cdl) {
+			this.cdl = cdl;
+		}
+
+		@OnOpen
+		public void onOpen(Session session) {
+			try {
+				JsonObject ping = Json.createObjectBuilder().add("chat", "ping").build();
+				session.getBasicRemote().sendObject(ping);
+			} catch (IOException | EncodeException e) {
+				e.printStackTrace();
+				fail(e.getMessage());
+			}
+		}
+
+		@OnMessage
+		public void onMessage(JsonObject message, Session session) {
+			cdl.countDown();
+			if (cdl.getCount() > 0) {
+				try {
+					JsonObject ping = Json.createObjectBuilder().add("chat", "ping").build();
+					session.getBasicRemote().sendObject(ping);
+				} catch (IOException | EncodeException e) {
+					e.printStackTrace();
+					fail(e.getMessage());
+				}
+			}
+
+		}
+
+		@OnClose
+		public void onClose(Session session, CloseReason closeReason) {
+
+		}
+
+	}
+
+}

--- a/meecrowave-core/src/main/java/org/apache/meecrowave/cxf/CxfCdiAutoSetup.java
+++ b/meecrowave-core/src/main/java/org/apache/meecrowave/cxf/CxfCdiAutoSetup.java
@@ -318,7 +318,8 @@ public class CxfCdiAutoSetup implements ServletContainerInitializer {
 
             // just logging the endpoints
             final LogFacade log = new LogFacade(CxfCdiAutoSetup.class.getName());
-            final DestinationRegistry registry = getDestinationRegistryFromBusOrDefault(null);
+            String transportId = sc.getInitParameter(TRANSPORT_ID);
+            final DestinationRegistry registry = getDestinationRegistryFromBusOrDefault(transportId);
             prefixes = registry.getDestinations().stream()
                     .filter(ServletDestination.class::isInstance)
                     .map(ServletDestination.class::cast)


### PR DESCRIPTION
A minor fix so that Meecrowave is aware of destinations configured on the non-default HTTP transport.