### PR TITLE
Fixing the compiler args (should be passed as list)

### DIFF
--- a/meecrowave-oauth2/pom.xml
+++ b/meecrowave-oauth2/pom.xml
@@ -112,7 +112,9 @@
         <version>3.5.1</version>
         <configuration>
           <fork>true</fork>
-          <compilerArgs>-XDignore.symbol.file</compilerArgs>
+          <compilerArgs>
+             <arg>-XDignore.symbol.file</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Minor issue, it seems like compiler args should be passed as list, not as string, per plugin documentation (https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#compilerArgs)

```
<compilerArgs>
  <arg>-Xmaxerrs=1000</arg>
  <arg>-Xlint</arg>
  <arg>-J-Duser.language=en_us</arg>
</compilerArgs>
```

Thanks!