### PR TITLE
JPA : In case of bad configuration, the original exception is lost because …

### DIFF
--- a/meecrowave-jpa/src/main/java/org/apache/meecrowave/jpa/internal/EntityManagerContext.java
+++ b/meecrowave-jpa/src/main/java/org/apache/meecrowave/jpa/internal/EntityManagerContext.java
@@ -127,7 +127,10 @@ public class EntityManagerContext implements AlterableContext {
         }
 
         private <T> void doDestroy(final Contextual<T> contextual, final BeanInstanceBag<T> bag) {
-            contextual.destroy(bag.beanInstance, bag.beanCreationalContext);
+            if ( bag.beanInstance !=null ) {
+                // check null here because in case of missconfiguration, this can raise an NPE and hide the original exception
+                contextual.destroy(bag.beanInstance, bag.beanCreationalContext);
+            }
             bag.beanCreationalContext.release();
         }
 

--- a/meecrowave-jpa/src/test/java/org/apache/meecrowave/jpa/internal/exceptionlost/JPAExceptionLostTest.java
+++ b/meecrowave-jpa/src/test/java/org/apache/meecrowave/jpa/internal/exceptionlost/JPAExceptionLostTest.java
@@ -1,0 +1,119 @@
+package org.apache.meecrowave.jpa.internal.exceptionlost;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.meecrowave.Meecrowave;
+import org.apache.meecrowave.jpa.api.Jpa;
+import org.apache.meecrowave.jpa.api.PersistenceUnitInfoBuilder;
+import org.apache.meecrowave.jpa.api.Unit;
+import org.apache.meecrowave.junit.MeecrowaveRule;
+import org.apache.openjpa.persistence.ArgumentException;
+import org.h2.Driver;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.sql.DataSource;
+
+public class JPAExceptionLostTest {
+
+    @Rule
+    public final TestRule rule = new MeecrowaveRule(
+            new Meecrowave.Builder()
+                    .randomHttpPort()
+                    .includePackages(this.getClass().getPackage().getName()), "")
+            .inject(this);
+
+
+    @Inject
+    private BadService badService;
+
+    @Test
+    public void test_originalExceptionNotOverriden() {
+        try {
+            badService.save(new BadUser("test"));
+            Assert.fail("should fail");
+        } catch (Throwable throwable) {
+            Assert.assertTrue("Original Exception has been lost",throwable instanceof ArgumentException);
+            Assert.assertTrue(throwable.getMessage().contains("Unenhanced classes must have a public or protected no-args constructor."));
+        }
+
+    }
+
+    public static class BadService {
+
+        @Inject
+        @Unit(name = "test")
+        private EntityManager em;
+
+        @Jpa(transactional = true)
+        public BadUser save(final BadUser user) {
+            em.persist(user);
+            return user;
+        }
+
+        @Jpa(transactional = false) // no tx
+        public BadUser find(final long id) {
+            return em.find(BadUser.class, id);
+        }
+
+    }
+
+    @ApplicationScoped
+    public static class JpaConfig {
+        @Produces
+        public PersistenceUnitInfoBuilder unit(final DataSource ds) {
+            return new PersistenceUnitInfoBuilder()
+                    .setUnitName("test")
+                    .setDataSource(ds)
+                    .setExcludeUnlistedClasses(true)
+                    .addManagedClazz(BadUser.class)
+                    .addProperty("openjpa.RuntimeUnenhancedClasses", "supported")
+                    .addProperty("openjpa.jdbc.SynchronizeMappings", "buildSchema");
+        }
+
+        @Produces
+        @ApplicationScoped
+        public DataSource dataSource() {
+            final BasicDataSource source = new BasicDataSource();
+            source.setDriver(new Driver());
+            source.setUrl("jdbc:h2:mem:jpaextensiontest");
+            return source;
+        }
+    }
+
+    @Entity
+    @Dependent
+    public static class BadUser {
+        @Id
+        @GeneratedValue
+        private long id;
+
+        private String name;
+
+        public long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public BadUser(String name) {
+            this.name = name;
+        }
+    }
+
+}

--- a/meecrowave-jpa/src/test/java/org/apache/meecrowave/jpa/internal/exceptionlost/JPAExceptionLostTest.java
+++ b/meecrowave-jpa/src/test/java/org/apache/meecrowave/jpa/internal/exceptionlost/JPAExceptionLostTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.meecrowave.jpa.internal.exceptionlost;
 
 import org.apache.commons.dbcp2.BasicDataSource;


### PR DESCRIPTION
…the context try to release an EntityManager instance that has never been created. So it's generating an NPE.

I have added a check of null instance in the EntityManager Context close.